### PR TITLE
Remove broken split provides (bnc#921353)

### DIFF
--- a/package/yast2-inetd.changes
+++ b/package/yast2-inetd.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jun  2 15:47:07 UTC 2015 - lslezak@suse.cz
+
+- remove broken split provides, causes yast2-inetd-doc package
+  reinstallation (bnc#921353)
+- 3.1.11
+
+-------------------------------------------------------------------
 Thu Dec  4 09:50:15 UTC 2014 - jreidinger@suse.com
 
 - remove X-KDE-Library from desktop file (bnc#899104)

--- a/package/yast2-inetd.spec
+++ b/package/yast2-inetd.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-inetd
-Version:        3.1.10
+Version:        3.1.11
 Release:        0
 Url:            https://github.com/yast/yast-inetd
 
@@ -78,7 +78,6 @@ The YaST2 component for configuring the inetd and xinetd daemons.
 Group:		System/YaST
 
 Requires:	yast2-inetd
-Provides:	yast2-inetd:/usr/share/doc/packages/yast2-inetd/
 
 Summary:	YaST2 - Network Services Configuration
 


### PR DESCRIPTION
It causes yast2-inetd-doc package reinstallation.

See https://bugzilla.suse.com/show_bug.cgi?id=921353 for more details.