### PR TITLE
Fix AutoYaST schema in SLE 12 SP1

### DIFF
--- a/package/yast2-inetd.changes
+++ b/package/yast2-inetd.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Nov 16 17:17:04 UTC 2015 - igonzalezsosa@suse.com
+
+- Fix validation of AutoYaST profiles (bsc#954412)
+
+-------------------------------------------------------------------
 Tue Jun  2 15:47:07 UTC 2015 - lslezak@suse.cz
 
 - remove broken split provides, causes yast2-inetd-doc package

--- a/src/autoyast-rnc/inetd.rnc
+++ b/src/autoyast-rnc/inetd.rnc
@@ -8,13 +8,15 @@ inetd = element inetd {
 	LIST,
 	element conf {
 	    element enabled  { BOOLEAN }? &
-            element iid      { text }? &
-            element protocol { text }? &
-            element script   { text }? &
-            element server   { text }? &
-            element comment  { text }? &
-            element unparsed { text }? &
-            element service  {
+            element iid             { text }? &
+            element protocol        { text }? &
+            element script          { text }? &
+            element server          { text }? &
+            element comment         { text }? &
+            element comment_inside  { text }? &
+            element unparsed        { text }? &
+            element server_args     { text }? &
+            element service         {
 		# Bug 215668 - jing - false positive error
 		#   (attribute "type" from ... not allowed at this point;...)
 		attribute config:type { "boolean" }?, text
@@ -22,5 +24,5 @@ inetd = element inetd {
 	}*
     }? &
     element netd_service { SYMBOL }? &
-    element netd_status  { INTEGER }?
+    element netd_status  { BOOLEAN }?
 }


### PR DESCRIPTION
Fixes [bsc#954412](https://bugzilla.suse.com/show_bug.cgi?id=954412) for SLE 12 SP1. BTW, `SLE-12-GA` branch is merged into `sle-12-sp1-after_release`.