### PR TITLE
Synchronize IBS content

### DIFF
--- a/package/yast2-inetd.changes
+++ b/package/yast2-inetd.changes
@@ -2,7 +2,13 @@
 Mon Nov 16 17:17:04 UTC 2015 - igonzalezsosa@suse.com
 
 - Fix validation of AutoYaST profiles (bsc#954412)
-- 3.1.9.1
+- 3.1.10.1
+
+-------------------------------------------------------------------
+Thu Dec  4 09:50:15 UTC 2014 - jreidinger@suse.com
+
+- remove X-KDE-Library from desktop file (bnc#899104)
+- 3.1.10
 
 -------------------------------------------------------------------
 Mon Sep 29 10:51:23 CEST 2014 - schubi@suse.de

--- a/package/yast2-inetd.spec
+++ b/package/yast2-inetd.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-inetd
-Version:        3.1.9.1
+Version:        3.1.10.1
 Release:        0
 Url:            https://github.com/yast/yast-inetd
 

--- a/src/desktop/inetd.desktop
+++ b/src/desktop/inetd.desktop
@@ -4,7 +4,6 @@ Categories=Settings;System;Qt;X-SuSE-YaST;X-SuSE-YaST-Net_advanced;
 
 X-KDE-ModuleType=Library
 X-KDE-HasReadOnlyMode=true
-X-KDE-Library=yast2
 X-SuSE-YaST-Call=inetd
 
 X-SuSE-YaST-Group=Net_advanced


### PR DESCRIPTION
For some strange reason yast2-inetd was out of sync with this repository (version in IBS was 3.1.10 instead of 3.1.9). So I'm merging the changes up to https://github.com/yast/yast-inetd/commit/8cb7696dc56905867c1071d67c31238680e5bf09