### PR TITLE
Fixed build failure (jemalloc warning) (bsc#1068883)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+/.yardoc/
+/yardoc/
+/coverage/
 Makefile
 /Makefile.am
 Makefile.in
@@ -30,7 +33,7 @@ tmp.*
 /doc/autodocs/
 /testsuite/config/
 /testsuite/raw.*
-/testsuite/run/
+/testsuite/run/runtest.sh
 /testsuite/*.exp
 /testsuite/tests.ag/*.in.test
 /testsuite/tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /.yardoc/
-/yardoc/
+/doc/autodoc
 /coverage/
 Makefile
 /Makefile.am

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,3 @@
+# generate the output to different directory to not
+# overwrite the existing documentation there
+-o yardoc

--- a/.yardopts
+++ b/.yardopts
@@ -1,3 +1,3 @@
 # generate the output to different directory to not
 # overwrite the existing documentation there
--o yardoc
+-o doc/autodoc

--- a/package/yast2-inetd.changes
+++ b/package/yast2-inetd.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Nov 30 08:46:47 UTC 2017 - lslezak@suse.cz
+
+- Fixed build failure caused by a jemalloc warning printed on
+  the STDERR (bsc#1068883)
+- 4.0.0
+
+-------------------------------------------------------------------
 Tue Jun  7 11:27:35 UTC 2016 - igonzalezsosa@suse.com
 
 - Stop generating autodocs (fate#320356)

--- a/package/yast2-inetd.spec
+++ b/package/yast2-inetd.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-inetd
-Version:        3.1.13
+Version:        4.0.0
 Release:        0
 Url:            https://github.com/yast/yast-inetd
 

--- a/testsuite/run/runtest-ag.sh
+++ b/testsuite/run/runtest-ag.sh
@@ -14,6 +14,8 @@ export Y2ALLGLOBAL=1
 shopt -s expand_aliases
 alias kick-nonerror-lines="grep -v -e ' <[0-2]> '"
 alias kick-empty-lines="grep -v '^$'"
+# workaround for a jemalloc issue (bsc#1068883)
+alias kick-jemalloc-warning="grep -v '^<main>: warning: pthread_create failed for timer: '"
 alias strip-constant-part="sed 's/^....-..-.. ..:..:.. [^)]*) //g'"
 alias mask-line-numbers="sed 's/^\([^ ]* [^)]*):\)[[:digit:]]*/\1XXX/'"
 
@@ -45,6 +47,7 @@ Y=/usr/lib/YaST2/bin/y2base
 Y2DIR="$AGDIR" $Y -l - 2>&1 >"$OUT_TMP" "$YCP" '("'"$IN.test"'")' testsuite \
     | kick-nonerror-lines \
     | kick-empty-lines \
+    | kick-jemalloc-warning \
     | strip-constant-part \
     | mask-line-numbers \
     > "$ERR_TMP"


### PR DESCRIPTION
- Note: the agent tests use a different y2log filtering than the usual tests so it failed here.
- Adapted `.gitignore` and added `.yardopts` to avoid Travis failures
- 4.0.0

